### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 license = "GPL-2.0-only"
 
 [dependencies]
-libc = "0.2.82"
-clap = "2.33.3"
+libc = "0.2.138"
+clap = "2.34.0"
 rusb = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ license = "GPL-2.0-only"
 
 [dependencies]
 libc = "0.2.138"
-clap = "2.34.0"
+clap = { version = "4.0.30", features = ["cargo"] }
 rusb = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ license = "GPL-2.0-only"
 [dependencies]
 libc = "0.2.138"
 clap = "2.34.0"
-rusb = "0.7.0"
+rusb = "0.9.1"

--- a/src/bin/fusee-gelee.rs
+++ b/src/bin/fusee-gelee.rs
@@ -1,38 +1,38 @@
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, Arg, Command};
 use std::fs::File;
 
 use fusee::{ExploitDriver, LinuxBackend};
 
 fn main() {
-    let args = App::new("fusee")
+    let args = Command::new("fusee")
         .version(crate_version!())
         .arg(
-            Arg::with_name("payload")
+            Arg::new("payload")
                 .required(true)
-                .takes_value(true)
                 .help("Path to ARM payload to launch"),
         )
         .arg(
-            Arg::with_name("vendor-id")
-                .short("V")
+            Arg::new("vendor-id")
+                .short('v')
                 .default_value("0955")
                 .help("Vendor ID, hexadecimal encoded"),
         )
         .arg(
-            Arg::with_name("product-id")
-                .short("P")
+            Arg::new("product-id")
+                .short('p')
                 .default_value("7321")
                 .help("Product ID, hexadecimal encoded"),
         )
         .get_matches();
 
     let vendor_id = u16::from_str_radix(
-        args.value_of("vendor-id").expect("Vendor ID not provided"),
+        args.get_one::<String>("vendor-id")
+            .expect("Vendor ID not provided"),
         16,
     )
     .expect("Vendor ID must be a 16-bit hexadecimal integer.");
     let product_id = u16::from_str_radix(
-        args.value_of("product-id")
+        args.get_one::<String>("product-id")
             .expect("Product ID not provided"),
         16,
     )
@@ -41,8 +41,11 @@ fn main() {
     let mut driver: ExploitDriver<LinuxBackend> =
         ExploitDriver::discover(vendor_id, product_id).expect("Failed to find USB device");
 
-    let target_payload = File::open(args.value_of("payload").expect("Payload path not provided"))
-        .expect("Failed to open payload file");
+    let target_payload = File::open(
+        args.get_one::<String>("payload")
+            .expect("Payload path not provided"),
+    )
+    .expect("Failed to open payload file");
     driver
         .exploit(target_payload, &fusee::payload::INTERMEZZO_DEFAULT[..])
         .expect("Failed to execute exploit");


### PR DESCRIPTION
simple PR to:
- use gitignore
- upgrade all deps to latest
- some minor changes related to clap major bump. The command line flags V and P have been renamed to v and p lowercase, so we can reuse the autogenerated -V implementation to print the tool version.
- code formatting

when I have time after this I will try to see about adding a macOS backend or at least macOS testing